### PR TITLE
Fetch data from a remote https url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ Cargo.lock
 # Added by cargo
 
 /target
+
+#custom
+tmp

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.0.23", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "4.0.23", features = ["derive"] }
+git2 = "0.15.0"
+url = "2.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "waking"
+name = "wake"
 version = "0.1.0"
 edition = "2021"
 
@@ -9,3 +9,7 @@ edition = "2021"
 clap = { version = "4.0.23", features = ["derive"] }
 git2 = "0.15.0"
 url = "2.3.1"
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "waking-git"
+name = "waking"
 version = "0.1.0"
 edition = "2021"
 

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,0 +1,27 @@
+pub mod scan;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// scans a git repository and extracts world data
+    Scan(scan::RunCmd),
+}
+
+/// `Wake` git repository world generator
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+pub fn run() {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::Scan(cmd) => {
+            scan::run(cmd);
+        }
+    }
+}

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
 #[derive(Subcommand, Debug)]
 enum Commands {
     /// scans a git repository and extracts world data
-    Scan(scan::RunCmd),
+    Scan(scan::RunArgs),
 }
 
 /// `Wake` git repository world generator
@@ -20,8 +20,8 @@ pub fn run() {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Scan(cmd) => {
-            scan::run(cmd);
+        Commands::Scan(args) => {
+            scan::run(args);
         }
     }
 }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -1,6 +1,7 @@
 pub mod scan;
 
 use clap::{Parser, Subcommand};
+use crate::config;
 
 #[derive(Subcommand, Debug)]
 enum Commands {
@@ -16,12 +17,12 @@ struct Cli {
     command: Commands,
 }
 
-pub fn run() {
+pub fn run(conf: config::Config) {
     let cli = Cli::parse();
 
     match &cli.command {
         Commands::Scan(args) => {
-            scan::run(args);
+            scan::run(args, conf);
         }
     }
 }

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -1,22 +1,26 @@
 use crate::config;
 use clap::Args;
+use git2::Repository;
 use std::fs;
 use std::path;
+use std::io::Error;
+use std::process;
+use url::{Host, Position, Url};
 
 #[derive(Args, Debug)]
 pub struct RunArgs {
     /// the path to the repository we want to scan
     #[clap(value_name = "REPOSITORY", index = 1)]
-    repos: Option<String>,
+    repository: Option<String>,
 }
 
 pub fn run(args: &RunArgs, conf: config::Config) {
-    let repos = args.repos.clone().unwrap_or("".to_string());
+    let repo = args.repository.clone().unwrap_or("".to_string());
 
-    fetch_repository(repos, conf);
+    clone_repository(repo, conf);
 }
 
-pub fn fetch_repository(repos: String, conf: config::Config) {
+pub fn clone_repository(repo: String, conf: config::Config) {
     //Create the temporary directory if it doesn't exist
     let path = path::Path::new(&conf.tmp_folder);
     if !path.exists() {
@@ -25,5 +29,59 @@ pub fn fetch_repository(repos: String, conf: config::Config) {
         });
         println!("`{}` Temporary folder was created", conf.tmp_folder);
     }
-    println!("I will fetch the repository than store it's content");
+
+    //Validate url and extract repository name
+    let repo_name: String;
+    let repo_owner: String;
+    let mut host_name: String;
+    let url = Url::parse(&repo);
+    match url {
+        Err(err) => {
+            println!("Failed to parse `{}` repository url: {}", repo, err);
+            return
+        },
+        Ok(url) => {
+            //Check that the repo is a url
+            if url.scheme() != "https" {
+               println!("Failed to fetch the repository: Repository not a https url");
+               return
+            }
+
+            //Extract repository name and owner
+            let path_segments: Vec<&str> = url.path().split("/").collect();
+            if path_segments.len() <= 2 {
+                println!("Failed to parse repository owner and name from `{}`", url);
+                return
+            }
+
+            repo_owner = path_segments[1].to_string();
+            repo_name = path_segments[2].to_string();
+            let host_str = url.host_str();
+            match host_str {
+                Some(h) => { host_name = format!("{}-", h) },
+                None => { host_name = "".to_string() }
+            }
+
+            host_name = host_name.replace(".", "-").to_string();
+        },
+    }
+
+    //Clone the repository if it doesn't exist on disk
+    let repo_path = format!("{}/{}{}-{}", conf.tmp_folder, host_name, repo_owner, repo_name);
+    let _git_repo: Repository;
+    let path = path::Path::new(&repo_path);
+    if !path.exists() {
+        _git_repo = match Repository::clone(repo.as_str(), &repo_path) {
+            Ok(git_repo) => git_repo,
+            Err(err) => {
+                println!("Failed to clone `{}` repository: {}", repo, err);
+                return;
+            },
+        };
+    } else {
+        println!("`{}` git repository already on disk", repo_path);
+        return
+    }
+
+    println!("`{}` repository cloned successfully", repo_path);
 }

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -1,8 +1,13 @@
 use clap::Args;
 
 #[derive(Args, Debug)]
-pub struct RunCmd {}
+pub struct RunArgs {
+    /// the path to the repository we want to scan
+    #[clap(value_name = "REPOSITORY", index = 1)]
+    repos: Option<String>
+}
 
-pub fn run(_cmd: &RunCmd) {
-    println!("scanner called");
+pub fn run(args: &RunArgs) {
+    let repos = args.repos.clone().unwrap_or("".to_string());
+    println!("scanner called: {:?}", repos);
 }

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -2,8 +2,8 @@ use crate::config;
 use clap::Args;
 use git2::Repository;
 use std::fs;
-use std::path;
 use std::io::Error;
+use std::path;
 use std::process;
 use url::{Host, Position, Url};
 
@@ -38,36 +38,39 @@ pub fn clone_repository(repo: String, conf: config::Config) {
     match url {
         Err(err) => {
             println!("Failed to parse `{}` repository url: {}", repo, err);
-            return
-        },
+            return;
+        }
         Ok(url) => {
             //Check that the repo is a url
             if url.scheme() != "https" {
-               println!("Failed to fetch the repository: Repository not a https url");
-               return
+                println!("Failed to fetch the repository: Repository not a https url");
+                return;
             }
 
             //Extract repository name and owner
             let path_segments: Vec<&str> = url.path().split("/").collect();
             if path_segments.len() <= 2 {
                 println!("Failed to parse repository owner and name from `{}`", url);
-                return
+                return;
             }
 
             repo_owner = path_segments[1].to_string();
             repo_name = path_segments[2].to_string();
             let host_str = url.host_str();
             match host_str {
-                Some(h) => { host_name = format!("{}-", h) },
-                None => { host_name = "".to_string() }
+                Some(h) => host_name = format!("{}-", h),
+                None => host_name = "".to_string(),
             }
 
             host_name = host_name.replace(".", "-").to_string();
-        },
+        }
     }
 
     //Clone the repository if it doesn't exist on disk
-    let repo_path = format!("{}/{}{}-{}", conf.tmp_folder, host_name, repo_owner, repo_name);
+    let repo_path = format!(
+        "{}/{}{}-{}",
+        conf.tmp_folder, host_name, repo_owner, repo_name
+    );
     let _git_repo: Repository;
     let path = path::Path::new(&repo_path);
     if !path.exists() {
@@ -76,11 +79,11 @@ pub fn clone_repository(repo: String, conf: config::Config) {
             Err(err) => {
                 println!("Failed to clone `{}` repository: {}", repo, err);
                 return;
-            },
+            }
         };
     } else {
         println!("`{}` git repository already on disk", repo_path);
-        return
+        return;
     }
 
     println!("`{}` repository cloned successfully", repo_path);

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -1,13 +1,29 @@
+use crate::config;
 use clap::Args;
+use std::fs;
+use std::path;
 
 #[derive(Args, Debug)]
 pub struct RunArgs {
     /// the path to the repository we want to scan
     #[clap(value_name = "REPOSITORY", index = 1)]
-    repos: Option<String>
+    repos: Option<String>,
 }
 
-pub fn run(args: &RunArgs) {
+pub fn run(args: &RunArgs, conf: config::Config) {
     let repos = args.repos.clone().unwrap_or("".to_string());
-    println!("scanner called: {:?}", repos);
+
+    fetch_repository(repos, conf);
+}
+
+pub fn fetch_repository(repos: String, conf: config::Config) {
+    //Create the temporary directory if it doesn't exist
+    let path = path::Path::new(&conf.tmp_folder);
+    if !path.exists() {
+        fs::create_dir(&conf.tmp_folder).unwrap_or_else(|err| {
+            println!("Failed to create `{}` folder: {}", conf.tmp_folder, err);
+        });
+        println!("`{}` Temporary folder was created", conf.tmp_folder);
+    }
+    println!("I will fetch the repository than store it's content");
 }

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -1,0 +1,8 @@
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct RunCmd {}
+
+pub fn run(_cmd: &RunCmd) {
+    println!("scanner called");
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,14 @@
+#[derive(Debug)]
+pub struct Config {
+    pub tmp_folder: String,
+}
+
+const DEFAULT_TMP_REPOSITORY: &str = "./tmp";
+
+impl Config {
+    pub fn new() -> Config {
+        Config {
+            tmp_folder: DEFAULT_TMP_REPOSITORY.to_string(),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod cmd;
+
 fn main() {
-    println!("Your git world generator!");
+    cmd::run();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 mod cmd;
+mod config;
 
 fn main() {
-    cmd::run();
+    let conf = config::Config::new();
+    cmd::run(conf);
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,26 @@
+use std::fs;
+use std::path;
+
+pub const TMP_DIR: &str = "/tmp/wake-tmp-folder";
+
+pub fn move_to_tmp_folder() {
+    //Create a temporary folder
+    //Create the temporary directory if it doesn't exist
+    let path = path::Path::new(TMP_DIR);
+    if !path.exists() {
+        fs::create_dir(TMP_DIR).unwrap();
+    }
+}
+
+pub fn delete_tmp_folder() {
+    let _ = fs::remove_dir_all(TMP_DIR); //silence the error
+}
+
+pub fn setup() {
+    delete_tmp_folder();
+    move_to_tmp_folder();
+}
+
+pub fn teardown() {
+    delete_tmp_folder();
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,44 @@
+use assert_cmd::prelude::*; // Add methods on commands
+use predicates::prelude::*; // Used for writing assertions
+use std::process::Command; // Run programs
+
+#[test]
+fn fail_to_parse_wrong_url() -> Result<(), Box<dyn std::error::Error>> {
+    struct Test<'a> {
+        url: &'a str,
+        exp: &'a str,
+    }
+
+    let tests = [
+        Test {
+            url: "./test/file/doesnt/exist",
+            exp: "Failed to parse",
+        },
+        Test {
+            url: "http://github.com",
+            exp: "not a https url",
+        },
+        Test {
+            url: "file://github.com",
+            exp: "not a https url",
+        },
+        Test {
+            url: "http://",
+            exp: "Failed to parse",
+        },
+        Test {
+            url: "",
+            exp: "Failed to parse",
+        },
+    ];
+
+    for t in tests {
+        let mut cmd = Command::cargo_bin("wake")?;
+        cmd.arg("scan").arg(t.url);
+        cmd.assert()
+            .success()
+            .stdout(predicate::str::contains(t.exp));
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This pull request allow us to clone a repository from a url.

`cargo run -- scan https://github.com/elhmn/ckp` should clone the repository and store it in a temporary directory `./tmp/github-com-elhmn-ckp`