### PR TITLE
Player generate entities from converter data

### DIFF
--- a/src/cmd/play.rs
+++ b/src/cmd/play.rs
@@ -20,7 +20,8 @@ pub fn run(args: &RunArgs, conf: config::Config) {
             r
         }
         Err(err) => {
-            return println!("Error: {err}");
+            println!("Error: {err}");
+            return;
         }
     };
 

--- a/src/cmd/play.rs
+++ b/src/cmd/play.rs
@@ -1,24 +1,47 @@
+use super::scan;
 use crate::config;
+use crate::converters;
 use crate::players::shmup;
 use clap::Args;
 
 #[derive(Args, Debug)]
 pub struct RunArgs {
-    /// the path to the directory to use to generate
-    /// the world.
-    /// example:
-    /// `wake play -d ./tmp/github-com-elhmn-ckp`
-    #[arg(short, long, value_name = "DIRECTORY")]
-    dir: Option<String>,
+    /// the path to the repository we want to play
+    #[clap(value_name = "REPOSITORY", index = 1)]
+    repository: Option<String>,
 }
 
-pub fn run(args: &RunArgs, _conf: config::Config) {
-    let dir = args.dir.clone().unwrap_or_default();
-    println!("Play run command invoked");
+pub fn run(args: &RunArgs, conf: config::Config) {
+    let repo = args.repository.clone().unwrap_or_default();
 
-    if !dir.is_empty() {
-        println!("Called with {dir}");
-    }
+    let git_repo = match scan::clone_repository(&repo, &conf) {
+        Ok(r) => {
+            println!("`{}` repository cloned successfully", repo);
+            r
+        }
+        Err(err) => {
+            return println!("Error: {}", err);
+        }
+    };
+
+    let extracted_data = match scan::extract_data(&conf, &git_repo) {
+        Ok(d) => d,
+        Err(err) => {
+            println!("Error: failed to extract repository data: {}", err);
+            return;
+        }
+    };
+
+    let conv = converters::shmup::new();
+    let converted_data = match scan::convert_data(&conf, &git_repo, extracted_data, &conv) {
+        Ok(d) => d,
+        Err(err) => {
+            println!("Error: failed to convert extracted data: {}", err);
+            return;
+        }
+    };
+
+    println!("Running the player...");
 
     // check if we are running the binary for integration tests
     // because we don't want to open a window while running tests
@@ -26,5 +49,5 @@ pub fn run(args: &RunArgs, _conf: config::Config) {
         return;
     }
 
-    shmup::run();
+    shmup::run(converted_data);
 }

--- a/src/cmd/play.rs
+++ b/src/cmd/play.rs
@@ -16,18 +16,18 @@ pub fn run(args: &RunArgs, conf: config::Config) {
 
     let git_repo = match scan::clone_repository(&repo, &conf) {
         Ok(r) => {
-            println!("`{}` repository cloned successfully", repo);
+            println!("`{repo}` repository cloned successfully");
             r
         }
         Err(err) => {
-            return println!("Error: {}", err);
+            return println!("Error: {err}");
         }
     };
 
     let extracted_data = match scan::extract_data(&conf, &git_repo) {
         Ok(d) => d,
         Err(err) => {
-            println!("Error: failed to extract repository data: {}", err);
+            println!("Error: failed to extract repository data: {err}");
             return;
         }
     };
@@ -36,7 +36,7 @@ pub fn run(args: &RunArgs, conf: config::Config) {
     let converted_data = match scan::convert_data(&conf, &git_repo, extracted_data, &conv) {
         Ok(d) => d,
         Err(err) => {
-            println!("Error: failed to convert extracted data: {}", err);
+            println!("Error: failed to convert extracted data: {err}");
             return;
         }
     };

--- a/src/converters/shmup/mod.rs
+++ b/src/converters/shmup/mod.rs
@@ -6,18 +6,18 @@ pub struct ShmupConverter {}
 
 const CONVERTER_NAME: &str = "shmup";
 
-#[derive(Serialize, Default)]
+#[derive(Serialize, Default, Debug)]
 pub struct Data {
     pub scenes: HashMap<String, Scene>,
 }
 
-#[derive(Serialize, Default)]
+#[derive(Serialize, Default, Debug)]
 pub struct Scene {
     pub entities: HashMap<String, Entity>,
     pub sub_scenes: Vec<String>,
 }
 
-#[derive(Serialize, Default)]
+#[derive(Serialize, Default, Debug)]
 pub struct Entity {
     pub id: String,
     //the scene id the object belongs to

--- a/src/players/shmup/mod.rs
+++ b/src/players/shmup/mod.rs
@@ -7,7 +7,12 @@ use bevy::diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin};
 use bevy::time::FixedTimestep;
 use bevy::{app::PluginGroupBuilder, prelude::*};
 
+use crate::converters;
+
 const TIMESTEP_60_FPS: f64 = 1. / 60.;
+
+#[derive(Resource, Default, Debug)]
+struct WorldData(converters::shmup::Data);
 
 fn default_plugins() -> PluginGroupBuilder {
     DefaultPlugins.set({
@@ -21,7 +26,7 @@ fn default_plugins() -> PluginGroupBuilder {
     })
 }
 
-pub fn run() {
+pub fn run(data: converters::shmup::Data) {
     App::new()
         .add_plugins(default_plugins())
         .add_plugin(LogDiagnosticsPlugin::default())
@@ -31,6 +36,7 @@ pub fn run() {
                 // This prints out "hello world" once every second
                 .with_run_criteria(FixedTimestep::step(TIMESTEP_60_FPS)),
         )
+        .insert_resource(WorldData(data))
         .add_plugin(plugin::ShmupPlugin)
         .run();
 }

--- a/src/players/shmup/plugin.rs
+++ b/src/players/shmup/plugin.rs
@@ -8,11 +8,12 @@ use rand::prelude::*;
 
 pub struct ShmupPlugin;
 
-const BACKGROUND_COLOR: Color = Color::rgb(0., 0., 0.);
-
 impl Plugin for ShmupPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(ClearColor(BACKGROUND_COLOR))
+        // set GitHub dark mode background color
+        let bg_color: Color = Color::hex("22272d").unwrap();
+
+        app.insert_resource(ClearColor(bg_color))
             .add_plugin(debug::DebugPlugin)
             .add_startup_system(setup)
             .add_startup_system(movements::pattern_3_init)
@@ -53,6 +54,14 @@ fn setup(
             );
 
             spawn_hexagon(
+                entity_id.to_string(),
+                &mut commands,
+                win,
+                &mut meshes,
+                &mut materials,
+            );
+
+            spawn_triangle(
                 entity_id.to_string(),
                 &mut commands,
                 win,
@@ -108,6 +117,30 @@ fn spawn_hexagon(
         .spawn(MaterialMesh2dBundle {
             mesh: meshes.add(shape::RegularPolygon::new(10., 6).into()).into(),
             material: materials.add(ColorMaterial::from(Color::TURQUOISE)),
+            transform: Transform::from_translation(get_random_position(win.width(), win.height())),
+            ..default()
+        })
+        .insert(patterns::Pattern3 {
+            speed: 150.,
+            ..default()
+        })
+        .insert(cell::Cell {
+            name: id,
+            ..Default::default()
+        });
+}
+
+fn spawn_triangle(
+    id: String,
+    commands: &mut Commands,
+    win: &Window,
+    meshes: &mut ResMut<Assets<Mesh>>,
+    materials: &mut ResMut<Assets<ColorMaterial>>,
+) {
+    commands
+        .spawn(MaterialMesh2dBundle {
+            mesh: meshes.add(shape::RegularPolygon::new(10., 3).into()).into(),
+            material: materials.add(ColorMaterial::from(Color::ORANGE_RED)),
             transform: Transform::from_translation(get_random_position(win.width(), win.height())),
             ..default()
         })

--- a/src/players/shmup/plugin.rs
+++ b/src/players/shmup/plugin.rs
@@ -2,7 +2,9 @@ use super::components::cell;
 use super::components::patterns;
 use super::debug;
 use super::systems::movements;
+use super::WorldData;
 use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use rand::prelude::*;
 
 pub struct ShmupPlugin;
 
@@ -23,58 +25,119 @@ impl Plugin for ShmupPlugin {
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
+    world_data: Res<WorldData>,
+    windows: Res<Windows>,
     mut materials: ResMut<Assets<ColorMaterial>>,
 ) {
+    let win = windows.primary();
+    let data = &world_data.0;
     commands.spawn(Camera2dBundle::default());
 
-    for i in 1..1000 {
-        // Circle
-        commands
-            .spawn(MaterialMesh2dBundle {
-                mesh: meshes.add(shape::Circle::new(10.).into()).into(),
-                material: materials.add(ColorMaterial::from(Color::PURPLE)),
-                transform: Transform::from_translation(Vec3::new(-100., 0., 0.)),
-                ..default()
-            })
-            .insert(patterns::Pattern3 {
-                speed: 200.,
-                ..default()
-            })
-            .insert(cell::Cell {
-                name: format!("{i}"),
-                ..Default::default()
-            });
+    //The scenes are traversed in a random order,
+    //which means that the first scene displayed will be different
+    //every time we run the program.
+    //This also means that the first scene won't correspond to
+    //the git repository root tree.
+    //
+    //To solve that we will later have to add a `data.root_scene` field
+    //to the `converters::shmup::Data` struct, so that we know what is the
+    //initial scene to display.
+    for scene in data.scenes.values() {
+        for entity_id in scene.entities.keys() {
+            spawn_circle(
+                entity_id.to_string(),
+                &mut commands,
+                win,
+                &mut meshes,
+                &mut materials,
+            );
 
-        // Hexagon
-        commands
-            .spawn(MaterialMesh2dBundle {
-                mesh: meshes.add(shape::RegularPolygon::new(10., 6).into()).into(),
-                material: materials.add(ColorMaterial::from(Color::TURQUOISE)),
-                transform: Transform::from_translation(Vec3::new(100., 200., 0.)),
-                ..default()
-            })
-            .insert(patterns::Pattern3 {
-                speed: 150.,
-                ..default()
-            });
+            spawn_hexagon(
+                entity_id.to_string(),
+                &mut commands,
+                win,
+                &mut meshes,
+                &mut materials,
+            );
 
-        // Rectangle
-        commands
-            .spawn(SpriteBundle {
-                sprite: Sprite {
-                    color: Color::rgb(0.25, 0.25, 0.75),
-                    custom_size: Some(Vec2::new(20.0, 20.0)),
-                    ..default()
-                },
-                ..default()
-            })
-            .insert(patterns::Pattern3 {
-                speed: 100.,
-                ..default()
-            })
-            .insert(cell::Cell {
-                name: "hello".to_string(),
-                ..Default::default()
-            });
+            spawn_rectangle(entity_id.to_string(), &mut commands, win);
+        }
     }
+}
+
+fn get_random_position(w: f32, h: f32) -> Vec3 {
+    let mut r = thread_rng();
+    let x = r.gen_range((-w / 2.)..w / 2.);
+    let y = r.gen_range((-h / 2.)..h / 2.);
+
+    Vec3::new(x, y, 0.)
+}
+
+fn spawn_circle(
+    id: String,
+    commands: &mut Commands,
+    win: &Window,
+    meshes: &mut ResMut<Assets<Mesh>>,
+    materials: &mut ResMut<Assets<ColorMaterial>>,
+) {
+    commands
+        .spawn(MaterialMesh2dBundle {
+            mesh: meshes.add(shape::Circle::new(10.).into()).into(),
+            material: materials.add(ColorMaterial::from(Color::PURPLE)),
+            transform: Transform::from_translation(get_random_position(win.width(), win.height())),
+            ..default()
+        })
+        .insert(patterns::Pattern3 {
+            speed: 200.,
+            ..default()
+        })
+        .insert(cell::Cell {
+            name: id,
+            ..Default::default()
+        });
+}
+
+fn spawn_hexagon(
+    id: String,
+    commands: &mut Commands,
+    win: &Window,
+    meshes: &mut ResMut<Assets<Mesh>>,
+    materials: &mut ResMut<Assets<ColorMaterial>>,
+) {
+    commands
+        .spawn(MaterialMesh2dBundle {
+            mesh: meshes.add(shape::RegularPolygon::new(10., 6).into()).into(),
+            material: materials.add(ColorMaterial::from(Color::TURQUOISE)),
+            transform: Transform::from_translation(get_random_position(win.width(), win.height())),
+            ..default()
+        })
+        .insert(patterns::Pattern3 {
+            speed: 150.,
+            ..default()
+        })
+        .insert(cell::Cell {
+            name: id,
+            ..Default::default()
+        });
+}
+
+fn spawn_rectangle(id: String, commands: &mut Commands, win: &Window) {
+    commands
+        .spawn(SpriteBundle {
+            sprite: Sprite {
+                color: Color::rgb(0.25, 0.25, 0.75),
+                custom_size: Some(Vec2::new(20.0, 20.0)),
+                ..default()
+            },
+            transform: Transform::from_translation(get_random_position(win.width(), win.height())),
+            ..default()
+        })
+        .insert(patterns::Pattern3 {
+            speed: 100.,
+            ..default()
+        })
+        .insert(cell::Cell {
+            name: id,
+            ..Default::default()
+        });
 }

--- a/tests/play_test.rs
+++ b/tests/play_test.rs
@@ -1,4 +1,5 @@
 use assert_cmd::prelude::*;
+use common::TMP_DIR;
 // Add methods on commands
 use predicates::prelude::*; // Used for writing assertions
 use std::process::Command; // Run programs
@@ -9,27 +10,15 @@ mod common;
 fn should_work_correctly() -> Result<(), Box<dyn std::error::Error>> {
     common::setup();
 
-    let mut cmd = Command::cargo_bin("wake")?;
-    cmd.current_dir(common::TMP_DIR).arg("play");
-    cmd.assert()
-        .success()
-        .stdout(predicate::str::contains("Play run command invoked"));
-
-    common::teardown();
-    Ok(())
-}
-
-#[test]
-fn should_work_correctly_with_dir_flag_set() -> Result<(), Box<dyn std::error::Error>> {
-    common::setup();
+    let url = "https://github.com/elhmn/ckp";
 
     let mut cmd = Command::cargo_bin("wake")?;
-    cmd.current_dir(common::TMP_DIR)
-        .arg("play")
-        .arg("-d a_directory");
+    cmd.current_dir(TMP_DIR).arg("play").arg(url);
+
+    //Test that the player is running
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("Play run command invoked"));
+        .stdout(predicate::str::contains("Running the player..."));
 
     common::teardown();
     Ok(())


### PR DESCRIPTION
This pull request creates entities from data generated by the `shmup` converter.

You can now pass an https url to the play command `wake play <https_url>`.
The command will fetch the repository, scan your repository and use the data extracted to load entities on the screen.

```
cargo run --features bevy/dynamic play https://github.com/elhmn/waking-git
```

The PR also now positions entities randomly on the screen. The UI did not massively change but here is an example.

https://user-images.githubusercontent.com/5704817/210199177-3e656d6f-c50a-47d1-adc6-80d51c58c75d.mp4


It addresses:
-  https://github.com/elhmn/waking-git/issues/27
- https://github.com/elhmn/waking-git/issues/28