### PR TITLE
Restrict git revision walk to a single commit

### DIFF
--- a/src/extractor/git.rs
+++ b/src/extractor/git.rs
@@ -135,39 +135,29 @@ pub fn extract_git_objects(repo: &repo::Repo) -> Result<Git, git2::Error> {
         }
     };
 
-    let mut walk = r.revwalk()?;
-    walk.push(oid)?;
-
     let mut objects: HashMap<String, Object> = HashMap::new();
-    //For each commit found from the references
-    for w in walk {
-        let mut obj = Object::new();
-        let oid = w?;
-        let commit = r.find_commit(oid)?;
+    let mut obj = Object::new();
+    let commit = r.find_commit(oid)?;
+    obj.kind = ObjectKind::Commit;
+    obj.commit = Some(Commit {
+        author: commit.author().to_string(),
+        sha: commit.id().to_string(),
+        message: commit.message().unwrap_or("").to_string(),
+        tree: commit.tree()?.id().to_string(),
+        committer: commit.committer().to_string(),
+        parents: {
+            let mut ids = vec![];
+            for id in commit.parent_ids() {
+                ids.push(id.to_string());
+            }
+            ids
+        },
+    });
+    //Add the commit object in the objects HashMap
+    objects.insert(oid.to_string(), obj);
 
-        obj.kind = ObjectKind::Commit;
-
-        //Get commits
-        obj.commit = Some(Commit {
-            author: commit.author().to_string(),
-            sha: commit.id().to_string(),
-            message: commit.message().unwrap_or("").to_string(),
-            tree: commit.tree()?.id().to_string(),
-            committer: commit.committer().to_string(),
-            parents: {
-                let mut ids = vec![];
-                for id in commit.parent_ids() {
-                    ids.push(id.to_string());
-                }
-                ids
-            },
-        });
-        //Add the commit object in the objects HashMap
-        objects.insert(oid.to_string(), obj);
-
-        //Add every git objects found during the tree object traversal
-        add_tree_objects(&commit.tree()?, &mut objects, r)?;
-    }
+    //Add every git objects found during the tree object traversal
+    add_tree_objects(&commit.tree()?, &mut objects, r)?;
 
     Ok(Git {
         objects,

--- a/src/extractor/git.rs
+++ b/src/extractor/git.rs
@@ -113,7 +113,7 @@ impl Object {
 }
 
 pub fn new(repo: &repo::Repo) -> Result<Git, String> {
-    let git_data = match extrat_git_objects(repo) {
+    let git_data = match extract_git_objects(repo) {
         Ok(d) => d,
         Err(err) => return Err(format!("failed to extract git objects: {}", err)),
     };
@@ -121,7 +121,7 @@ pub fn new(repo: &repo::Repo) -> Result<Git, String> {
     Ok(git_data)
 }
 
-pub fn extrat_git_objects(repo: &repo::Repo) -> Result<Git, git2::Error> {
+pub fn extract_git_objects(repo: &repo::Repo) -> Result<Git, git2::Error> {
     let r = &repo.repo;
 
     let mut ref_name = "refs/heads/master";


### PR DESCRIPTION
We were going through the complete list of commits.
This was unnecessary for the current application design
and was slowing down the extraction process considerably.

Maybe when we decide to extract data from every commits we will
perform a parallel revwalk again. It is also important to note
that we have spent a lot of time trying to figure out how we could
parallelize the revwalk process but it seemed to be very difficult
because the git2::Repository struc does not implement the Send and Sync
traits.

We are glad this solution was found as it speed up the extraction
process.

Should make #42  and  #21 irrelevant