### PR TITLE
Paralellise the shmup converter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ bevy-inspector-egui = "0.15.0"
 rand = "0.8.5"
 sha2 = "0.10.6"
 data-encoding = "2.3.3"
+rayon = "1.6.1"
 
 [dev-dependencies]
 assert_cmd = "2.0"


### PR DESCRIPTION
Here is a benchmark on the repository https://github.com/kubernetes/kubernetes

The test was run on a M2 Macbook Pro 

```
 Chip: Apple M1 Max
 Total Number of Cores:	10 (8 performance and 2 efficiency)
 Memory: 64 GB
```

Before ~= 1:52:79
```console
$time cargo run --features bevy/dynamic scan https://github.com/kubernetes/kubernetes
cargo run --features bevy/dynamic scan   110.53s user 2.28s system 100% cpu 1:52.79 total
```

After ~= 17.140
```console
$time cargo run --features bevy/dynamic scan https://github.com/kubernetes/kubernetes
cargo run --features bevy/dynamic scan   142.36s user 3.86s system 853% cpu 17.140 total
```