### PR TITLE
wake: fetch only the default branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 .PHONY: test
 test: install-deps
 	-lsof -i :$(TEST_SERVER_PORT) | grep LISTEN | awk '{print $$2}' | xargs kill -9
-	SERVER_PORT=$(TEST_SERVER_PORT) cargo test -- --test-threads 1
+	RUST_BACKTRACE=1 SERVER_PORT=$(TEST_SERVER_PORT) cargo test -- --test-threads 1
 
 ## lint: run linter over the entire code base
 .PHONY: lint

--- a/wake/Cargo.toml
+++ b/wake/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 [dependencies]
 core = { package="waking-git-core", path = "../waking-git-core" }
 clap = { version = "4.0.23", features = ["derive"] }
-git2 = "0.15.0"
+git2 = "0.20.4"
 url = "2.3.1"
 walkdir = "2.3.2"
 rust-code-analysis = "0.0.24"

--- a/wake/tests/scan_test.rs
+++ b/wake/tests/scan_test.rs
@@ -65,7 +65,7 @@ fn clone_repository() -> Result<(), Box<dyn std::error::Error>> {
     //we should be able clone the repository successfully
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("repository cloned successfully"));
+        .stderr(predicate::str::contains("repository cloned successfully"));
 
     //the ./wake/repos/github-com-elhmn-ckp directory should be created
     let dir = PathBuf::from(TMP_DIR);
@@ -96,12 +96,12 @@ fn doesnt_fetch_repository_if_already_exists() -> Result<(), Box<dyn std::error:
     //we should be able clone the repository successfully the first time
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("repository cloned successfully"));
+        .stderr(predicate::str::contains("repository cloned successfully"));
 
     //then work even though the repository already exist on disk
     cmd.assert()
         .success()
-        .stdout(predicate::str::contains("repository cloned successfully"));
+        .stderr(predicate::str::contains("repository cloned successfully"));
 
     test::teardown();
     Ok(())

--- a/wake/tests/scan_test.rs
+++ b/wake/tests/scan_test.rs
@@ -1,4 +1,4 @@
-use assert_cmd::prelude::*;
+use assert_cmd::{assert, prelude::*};
 use core::utils::test;
 use core::utils::test::TMP_DIR;
 use std::path::PathBuf;
@@ -73,6 +73,10 @@ fn clone_repository() -> Result<(), Box<dyn std::error::Error>> {
     let expected_dir = format!("{}/{}/{}", tmp_folder, "repos", "github-com-elhmn-ckp");
     println!("expected_dir: {expected_dir}");
     assert!(std::path::Path::new(expected_dir.as_str()).exists());
+
+    //Is it a shallow clone.
+    let shallow_file_path = format!("{expected_dir}/.git/shallow");
+    assert!(std::path::Path::new(shallow_file_path.as_str()).exists());
 
     //the ./tmp/scanner/github-com-elhmn-ckp/extracted.json directory should be created
     let expected_extracted_file = format!(

--- a/waking-git-core/Cargo.toml
+++ b/waking-git-core/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/elhmn/waking-git"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-git2 = "0.15.0"
+git2 = "0.20.4"
 url = "2.3.1"
 walkdir = "2.3.2"
 rust-code-analysis = "0.0.24"

--- a/waking-git-core/src/config.rs
+++ b/waking-git-core/src/config.rs
@@ -32,7 +32,7 @@ impl Config {
 pub fn get_home_dir() -> String {
     // check if we are running the binary for integration tests
     let dir: PathBuf = if std::env::var("WAKE_TEST_MODE").is_ok() {
-        PathBuf::from("./")
+        PathBuf::from(".")
     } else {
         match home::home_dir() {
             Some(d) => d,

--- a/waking-git-core/src/exec/mod.rs
+++ b/waking-git-core/src/exec/mod.rs
@@ -23,7 +23,7 @@ pub fn run_player(player: String, file: String) -> Result<String, io::Error> {
 
     if !output.status.success() {
         let err = String::from_utf8(output.stderr).unwrap_or(String::from(""));
-        return Err(io::Error::new(io::ErrorKind::Other, err));
+        return Err(io::Error::other(err));
     }
 
     let out = String::from_utf8(output.stdout).unwrap_or(String::from(""));

--- a/waking-git-core/src/repo/mod.rs
+++ b/waking-git-core/src/repo/mod.rs
@@ -1,5 +1,5 @@
 use crate::config;
-use git2::Repository;
+use git2::{build::RepoBuilder, Direction, FetchOptions, Repository};
 use std::fs;
 use std::path;
 use url::Url;
@@ -91,7 +91,43 @@ pub fn new_repo_from_url(url: String, conf: &config::Config) -> Result<Repo, Str
     let dest_path = format!("{repo_storage}/{folder_name}");
     let path = path::Path::new(&dest_path);
     let git_repo: Repository = if !path.exists() {
-        match Repository::clone(url.as_str(), &dest_path) {
+        let tmp_git2_repo = format!("/tmp/git2-{folder_name}");
+        let repo = match Repository::init(tmp_git2_repo.to_string()) {
+            Ok(r) => r,
+            Err(err) => {
+                return Err(format!("Failed to initialize repo {tmp_git2_repo}: {err}"));
+            }
+        };
+
+        // Fetch the default branch
+        let mut remote = match repo.remote_anonymous(url.as_str()) {
+            Ok(r) => r,
+            Err(err) => {
+                return Err(format!(
+                    "Failed to fetch the remote_anonymous of {url}: {err}"
+                ));
+            }
+        };
+        if let Err(err) = remote.connect(Direction::Fetch) {
+            return Err(format!("Failed to connect the remote: {err}"));
+        }
+        let default = match remote.default_branch() {
+            Ok(b) => b,
+            Err(err) => {
+                return Err(format!("Failed to get the default branch: {err}"));
+            }
+        };
+        let branch = default.as_str().unwrap().replace("refs/heads/", "");
+
+        // Set the --depth option to 1.
+        let mut fetch_option = FetchOptions::new();
+        fetch_option.depth(1);
+
+        let mut builder = RepoBuilder::new();
+        builder.branch(&branch);
+        builder.fetch_options(fetch_option);
+
+        match builder.clone(url.as_str(), &path) {
             Ok(git_repo) => git_repo,
             Err(err) => {
                 return Err(format!("Failed to clone `{url}` repository: {err}"));

--- a/waking-git-core/src/repo/mod.rs
+++ b/waking-git-core/src/repo/mod.rs
@@ -92,7 +92,7 @@ pub fn new_repo_from_url(url: String, conf: &config::Config) -> Result<Repo, Str
     let path = path::Path::new(&dest_path);
     let git_repo: Repository = if !path.exists() {
         let tmp_git2_repo = format!("/tmp/git2-{folder_name}");
-        let repo = match Repository::init(tmp_git2_repo.to_string()) {
+        let repo = match Repository::init(&tmp_git2_repo) {
             Ok(r) => r,
             Err(err) => {
                 return Err(format!("Failed to initialize repo {tmp_git2_repo}: {err}"));
@@ -127,7 +127,7 @@ pub fn new_repo_from_url(url: String, conf: &config::Config) -> Result<Repo, Str
         builder.branch(&branch);
         builder.fetch_options(fetch_option);
 
-        match builder.clone(url.as_str(), &path) {
+        match builder.clone(url.as_str(), path) {
             Ok(git_repo) => git_repo,
             Err(err) => {
                 return Err(format!("Failed to clone `{url}` repository: {err}"));


### PR DESCRIPTION
In order to fetch a repository faster, we only want to clone the default branch. And we don't really care about what the other branches.